### PR TITLE
Include new URL and assignee for etelemetry AWS service

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -25,9 +25,10 @@ sites:
   - name: Data portal Staging
     url: https://gui-staging.dandiarchive.org/
   - name: ETelemetry server
-    url: https://rig.mit.edu/et/
+    url: https://etelemetry.dandiarchive.org/
     assignees:
       - satra
+      - aaronkanzer
   - name: GitHub organization
     url: https://github.com/dandi
   - name: Hub


### PR DESCRIPTION
Relates to https://github.com/dandi/upptime/issues/387

Cc @yarikoptic @satra 

Not 100% sure why `upptime` would say the prior URL for `etelemetry` to be "down" -- nevertheless, this minor PR should point to the new proper URL, and adds myself as another assignnee